### PR TITLE
API Documentation notes 1 hr

### DIFF
--- a/doc_source/saas-code-examples.md
+++ b/doc_source/saas-code-examples.md
@@ -106,8 +106,8 @@ The following code example is relevant for SaaS subscription and contract with c
 ```
 # NOTE: Your application will need to aggregate usage for the 
 #       customer for the hour and set the quantity as seen below. 
-#       AWS Marketplace can only accept records for up to three 
-#       hours in the past. 
+#       AWS Marketplace can only accept records for up to an 
+#       hour in the past. 
 #
 # productCode is supplied after the AWS Marketplace Ops team has 
 # published the product to limited


### PR DESCRIPTION
"Your application can meter usage for up to one hour in the past. Make sure the timestamp value is not before the start of the software usage."
BatchMeterUsage API: https://docs.aws.amazon.com/marketplacemetering/latest/APIReference/API_BatchMeterUsage.html
UsageRecord Data Type: https://docs.aws.amazon.com/marketplacemetering/latest/APIReference/API_UsageRecord.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
